### PR TITLE
Avoid warnings during global destruction

### DIFF
--- a/lib/Promise/ES6/Backend/PP.pm
+++ b/lib/Promise/ES6/Backend/PP.pm
@@ -304,7 +304,7 @@ sub _settle_now {
 }
 
 sub DESTROY {
-    return if $$ != $_[0][_PID_IDX];
+    return unless $_[0][_PID_IDX] && $$ == $_[0][_PID_IDX];
 
     if ( $_[0][_DETECT_LEAK_IDX] && ${^GLOBAL_PHASE} && ${^GLOBAL_PHASE} eq 'DESTRUCT' ) {
         warn( ( '=' x 70 ) . "\n" . 'XXXXXX - ' . ref( $_[0] ) . " survived until global destruction; memory leak likely!\n" . ( "=" x 70 ) . "\n" );


### PR DESCRIPTION
This is avoiding errors like
```
# Warning was 'Use of uninitialized value in numeric ne (!=) at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Promise/ES6.pm line 418.
```