### PR TITLE
prevent circular reference between @resolves and closures

### DIFF
--- a/t/race_success.t
+++ b/t/race_success.t
@@ -13,6 +13,14 @@ use PromiseTest;
 
 use Promise::ES6;
 
+sub _bind {
+    my ($sub, @args) = @_;
+
+    return sub {
+        $sub->(@args, @_);
+    };
+}
+
 {
     my $eventer = Eventer->new();
 
@@ -21,22 +29,26 @@ use Promise::ES6;
     my $p1 = Promise::ES6->new(sub {
         my ($resolve, $reject) = @_;
 
-        push @resolves, sub {
-            if ($eventer->has_happened('ready1') && !$eventer->has_happened('resolved1')) {
-                $resolve->(1);
-                $eventer->happen('resolved1');
-            }
-        };
+        push @resolves,
+          _bind(sub {
+                    my ($eventer, $resolve) = @_;
+                    if ($eventer->has_happened('ready1') && !$eventer->has_happened('resolved1')) {
+                        $resolve->(1);
+                        $eventer->happen('resolved1');
+                    }
+                }, $eventer, $resolve);
     });
     my $p2 = Promise::ES6->new(sub {
         my ($resolve, $reject) = @_;
 
-        push @resolves, sub {
-            if ($eventer->has_happened('ready2') && !$eventer->has_happened('resolved2')) {
-                $reject->({ message => 'fail' });
-                $eventer->happen('resolved2');
-            }
-        };
+        push @resolves,
+          _bind(sub {
+                    my ($eventer, $reject) = @_;
+                    if ($eventer->has_happened('ready2') && !$eventer->has_happened('resolved2')) {
+                        $reject->({ message => 'fail' });
+                        $eventer->happen('resolved2');
+                    }
+                }, $eventer, $reject);
     });
 
     my $pid = fork or do {


### PR DESCRIPTION
This solution works by making the event handlers not closures.

Fixes #14