### PR TITLE
break circular reference loop between @resolves and closures

### DIFF
--- a/t/race_async.t
+++ b/t/race_async.t
@@ -57,9 +57,9 @@ use Promise::ES6;
 
     waitpid $pid, 0;
 
-    # This appears to be needed to solve a garbage-collection problem
-    # that Perl 5.18 fixed but that persists with Devel::Cover.
-    splice @resolves if $^V lt 5.18.0 || $INC{'Devel/Cover.pm'};
+    # break the circular reference loop between @resolves and
+    # the closures
+    @resolves = ();
 }
 
 done_testing();

--- a/t/race_fail.t
+++ b/t/race_fail.t
@@ -59,9 +59,9 @@ use Promise::ES6;
 
     waitpid $pid, 0;
 
-    # This appears to be needed to solve a garbage-collection problem
-    # that Perl 5.18 fixed but that persists with Devel::Cover.
-    splice @resolves if $^V lt 5.18.0 || $INC{'Devel/Cover.pm'};
+    # break the circular reference loop between @resolves and
+    # the closures
+    @resolves = ();
 }
 
 done_testing();

--- a/t/race_success.t
+++ b/t/race_success.t
@@ -56,9 +56,9 @@ use Promise::ES6;
 
     waitpid $pid, 0;
 
-    # This appears to be needed to solve a garbage-collection problem
-    # that Perl 5.18 fixed but that persists with Devel::Cover.
-    splice @resolves if $^V lt 5.18.0 || $INC{'Devel/Cover.pm'};
+    # break the circular reference loop between @resolves and
+    # the closures
+    @resolves = ();
 }
 
 done_testing();


### PR DESCRIPTION
This solution works by breaking the loop between @resolves, and the closures the objects it contains, contain

Fixes #14